### PR TITLE
update return type for notify-signals

### DIFF
--- a/CMenu-3.0.d.ts
+++ b/CMenu-3.0.d.ts
@@ -11,7 +11,7 @@ declare namespace imports.gi.CMenu {
 		 * This corresponds to the "Name" key within the keyfile group for the
 		 * action.
 		 * @param action_name the name of the action as from
-		 *   gmenu_desktopappinfo_list_actions()
+		 *   {@link CMenu.DesktopAppInfo.list_actions}
 		 * @returns the locale-specific action name
 		 */
 		get_action_name(action_name: string): string;
@@ -33,7 +33,7 @@ declare namespace imports.gi.CMenu {
 		/**
 		 * When #info was created from a known filename, return it.  In some
 		 * situations such as the #GMenuDesktopAppInfo returned from
-		 * gmenu_desktopappinfo_new_from_keyfile(), this function will return %NULL.
+		 * {@link CMenu.DesktopAppInfo.new_from_keyfile}, this function will return %NULL.
 		 * @returns The full path to the file for #info,
 		 *     or %NULL if not known.
 		 */
@@ -74,7 +74,7 @@ declare namespace imports.gi.CMenu {
 		/**
 		 * Gets the value of the NoDisplay key, which helps determine if the
 		 * application info should be shown in menus. See
-		 * #G_KEY_FILE_DESKTOP_KEY_NO_DISPLAY and g_app_info_should_show().
+		 * #G_KEY_FILE_DESKTOP_KEY_NO_DISPLAY and {@link Gio.AppInfo.should_show}.
 		 * @returns The value of the NoDisplay key
 		 */
 		get_nodisplay(): boolean;
@@ -88,7 +88,7 @@ declare namespace imports.gi.CMenu {
 		 * to override the default mechanism then you may specify #desktop_env,
 		 * but this is not recommended.
 		 * 
-		 * Note that g_app_info_should_show() for #info will include this check (with
+		 * Note that {@link Gio.AppInfo.should_show} for #info will include this check (with
 		 * %NULL for #desktop_env) as well as additional checks.
 		 * @param desktop_env a string specifying a desktop name
 		 * @returns %TRUE if the #info should be shown in #desktop_env according to the
@@ -127,7 +127,7 @@ declare namespace imports.gi.CMenu {
 		 * Activates the named application action.
 		 * 
 		 * You may only call this function on action names that were
-		 * returned from g_desktop_app_info_list_actions().
+		 * returned from {@link Gio.DesktopAppInfo.list_actions}.
 		 * 
 		 * Note that if the main entry of the desktop file indicates that the
 		 * application supports startup notification, and #launch_context is
@@ -140,12 +140,12 @@ declare namespace imports.gi.CMenu {
 		 * As with g_app_info_launch() there is no way to detect failures that
 		 * occur while using this function.
 		 * @param action_name the name of the action as from
-		 *   g_desktop_app_info_list_actions()
+		 *   {@link Gio.DesktopAppInfo.list_actions}
 		 * @param launch_context a #GAppLaunchContext
 		 */
 		launch_action(action_name: string, launch_context: Gio.AppLaunchContext | null): void;
 		/**
-		 * This function performs the equivalent of g_app_info_launch_uris(),
+		 * This function performs the equivalent of {@link Gio.AppInfo.launch_uris},
 		 * but is intended primarily for operating system components that
 		 * launch applications.  Ordinary applications should use
 		 * g_app_info_launch_uris().
@@ -237,7 +237,7 @@ declare namespace imports.gi.CMenu {
 		menu_path: string;
 		/**
 		 * This function is only available if the tree has been loaded via
-		 * gmenu_tree_load_sync() or a variant thereof.
+		 * {@link CMenu.Tree.load_sync} or a variant thereof.
 		 * @returns The absolute and canonicalized path to the loaded menu file
 		 */
 		get_canonical_menu_path(): string;
@@ -250,7 +250,7 @@ declare namespace imports.gi.CMenu {
 		get_entry_by_id(id: string): TreeEntry;
 		/**
 		 * Get the root directory; you must have loaded the tree first (at
-		 * least once) via gmenu_tree_load_sync() or a variant thereof.
+		 * least once) via {@link CMenu.Tree.load_sync} or a variant thereof.
 		 * @returns Root of the tree
 		 */
 		get_root_directory(): TreeDirectory;
@@ -263,9 +263,9 @@ declare namespace imports.gi.CMenu {
 		load_sync(): boolean;
 		connect(signal: "changed", callback: (owner: this) => void): number;
 
-		connect(signal: "notify::flags", callback: (owner: this, ...args: any) => number): number;
-		connect(signal: "notify::menu_basename", callback: (owner: this, ...args: any) => number): number;
-		connect(signal: "notify::menu_path", callback: (owner: this, ...args: any) => number): number;
+		connect(signal: "notify::flags", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::menu_basename", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::menu_path", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -292,12 +292,6 @@ declare namespace imports.gi.CMenu {
 		public static item_unref(item: any | null): void;
 	}
 
-	export interface DesktopAppInfoClassInitOptions {}
-	interface DesktopAppInfoClass {}
-	class DesktopAppInfoClass {
-		public constructor(options?: Partial<DesktopAppInfoClassInitOptions>);
-	}
-
 	export interface TreeAliasInitOptions {}
 	interface TreeAlias {}
 	class TreeAlias {
@@ -312,12 +306,6 @@ declare namespace imports.gi.CMenu {
 		 * @returns The #GMenuTree
 		 */
 		public get_tree(): Tree;
-	}
-
-	export interface TreeClassInitOptions {}
-	interface TreeClass {}
-	class TreeClass {
-		public constructor(options?: Partial<TreeClassInitOptions>);
 	}
 
 	export interface TreeDirectoryInitOptions {}
@@ -382,31 +370,31 @@ declare namespace imports.gi.CMenu {
 	class TreeIter {
 		public constructor(options?: Partial<TreeIterInitOptions>);
 		/**
-		 * This method may only be called if gmenu_tree_iter_next()
+		 * This method may only be called if {@link CMenu.TreeIter.next}
 		 * returned GMENU_TREE_ITEM_ALIAS.
 		 * @returns An alias
 		 */
 		public get_alias(): TreeAlias;
 		/**
-		 * This method may only be called if gmenu_tree_iter_next()
+		 * This method may only be called if {@link CMenu.TreeIter.next}
 		 * returned GMENU_TREE_ITEM_DIRECTORY.
 		 * @returns A directory
 		 */
 		public get_directory(): TreeDirectory;
 		/**
-		 * This method may only be called if gmenu_tree_iter_next()
+		 * This method may only be called if {@link CMenu.TreeIter.next}
 		 * returned GMENU_TREE_ITEM_ENTRY.
 		 * @returns An entry
 		 */
 		public get_entry(): TreeEntry;
 		/**
-		 * This method may only be called if gmenu_tree_iter_next()
+		 * This method may only be called if {@link CMenu.TreeIter.next}
 		 * returned GMENU_TREE_ITEM_HEADER.
 		 * @returns A header
 		 */
 		public get_header(): TreeHeader;
 		/**
-		 * This method may only be called if gmenu_tree_iter_next()
+		 * This method may only be called if {@link CMenu.TreeIter.next}
 		 * returned #GMENU_TREE_ITEM_SEPARATOR.
 		 * @returns A separator
 		 */

--- a/Cinnamon-0.1.d.ts
+++ b/Cinnamon-0.1.d.ts
@@ -10,7 +10,7 @@ declare namespace imports.gi.Cinnamon {
 		 */
 		readonly state: AppState;
 		/**
-		 * Like cinnamon_app_activate_full(), but using the default workspace and
+		 * Like {@link Cinnamon.App.activate_full}, but using the default workspace and
 		 * event timestamp.
 		 */
 		activate(): void;
@@ -38,7 +38,7 @@ declare namespace imports.gi.Cinnamon {
 		activate_window(window: Meta.Window | null, timestamp: number): void;
 		/**
 		 * Returns %TRUE if the app supports opening a new window through
-		 * cinnamon_app_open_new_window() (ie, if calling that function will
+		 * {@link Cinnamon.App.open_new_window} (ie, if calling that function will
 		 * result in actually opening a new window and not something else,
 		 * like presenting the most recently active one)
 		 * @returns 
@@ -116,7 +116,7 @@ declare namespace imports.gi.Cinnamon {
 		request_quit(): boolean;
 		connect(signal: "windows-changed", callback: (owner: this) => void): number;
 
-		connect(signal: "notify::state", callback: (owner: this, ...args: any) => number): number;
+		connect(signal: "notify::state", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -270,7 +270,7 @@ declare namespace imports.gi.Cinnamon {
 		 * allocate method.
 		 * 
 		 * Note that #box is #self's content box (qv
-		 * st_theme_node_get_content_box()), NOT its allocation.
+		 * {@link St.ThemeNode.get_content_box}), NOT its allocation.
 		 * @param signal 
 		 * @param callback Callback function
 		 *  - owner: owner of the emitted event 
@@ -281,7 +281,7 @@ declare namespace imports.gi.Cinnamon {
 		 */
 		connect(signal: "allocate", callback: (owner: this, box: Clutter.ActorBox, flags: Clutter.AllocationFlags) => void): number;
 		/**
-		 * Emitted when clutter_actor_get_preferred_height() is called
+		 * Emitted when {@link Clutter.Actor.get_preferred_height} is called
 		 * on #self. You should fill in the fields of #alloc with the
 		 * your minimum and natural heights. {@link GenericContainer}
 		 * will deal with taking its borders and padding into account
@@ -293,14 +293,14 @@ declare namespace imports.gi.Cinnamon {
 		 * @param signal 
 		 * @param callback Callback function
 		 *  - owner: owner of the emitted event 
-		 *  - for_width: as in clutter_actor_get_preferred_height() 
+		 *  - for_width: as in {@link Clutter.Actor.get_preferred_height} 
 		 *  - alloc: a {@link GenericContainerAllocation} to be filled in 
 		 * 
 		 * @returns Callback ID
 		 */
 		connect(signal: "get-preferred-height", callback: (owner: this, for_width: number, alloc: GenericContainerAllocation) => void): number;
 		/**
-		 * Emitted when clutter_actor_get_preferred_width() is called
+		 * Emitted when {@link Clutter.Actor.get_preferred_width} is called
 		 * on #self. You should fill in the fields of #alloc with the
 		 * your minimum and natural widths. {@link GenericContainer}
 		 * will deal with taking its borders and padding into account
@@ -312,7 +312,7 @@ declare namespace imports.gi.Cinnamon {
 		 * @param signal 
 		 * @param callback Callback function
 		 *  - owner: owner of the emitted event 
-		 *  - for_height: as in clutter_actor_get_preferred_width() 
+		 *  - for_height: as in {@link Clutter.Actor.get_preferred_width} 
 		 *  - alloc: a {@link GenericContainerAllocation} to be filled in 
 		 * 
 		 * @returns Callback ID
@@ -366,7 +366,7 @@ declare namespace imports.gi.Cinnamon {
 		alloc_leak(mb: number): void;
 		/**
 		 * Grabs the keyboard and mouse to the stage window. The stage will
-		 * receive all keyboard and mouse events until cinnamon_global_end_modal()
+		 * receive all keyboard and mouse events until {@link Cinnamon.Global.end_modal}
 		 * is called. This is used to implement "modes" for Cinnamon, such as the
 		 * overview mode or the "looking glass" debug overlay, that block
 		 * application and normal key shortcuts.
@@ -375,13 +375,13 @@ declare namespace imports.gi.Cinnamon {
 		 * @returns %TRUE if we successfully entered the mode. %FALSE if we couldn't
 		 *  enter the mode. Failure may occur because an application has the pointer
 		 *  or keyboard grabbed, because Muffin is in a mode itself like moving a
-		 *  window or alt-Tab window selection, or because cinnamon_global_begin_modal()
+		 *  window or alt-Tab window selection, or because {@link Cinnamon.Global.begin_modal}
 		 *  was previouly called.
 		 */
 		begin_modal(timestamp: number, options: Meta.ModalOptions): boolean;
 		/**
 		 * Marks that we are currently doing work. This is used to to track
-		 * whether we are busy for the purposes of cinnamon_global_run_at_leisure().
+		 * whether we are busy for the purposes of {@link Cinnamon.Global.run_at_leisure}.
 		 * A count is kept and cinnamon_global_end_work() must be called exactly
 		 * as many times as cinnamon_global_begin_work().
 		 */
@@ -399,11 +399,11 @@ declare namespace imports.gi.Cinnamon {
 		 * @param x2 right X coordinate
 		 * @param y2 bottom Y coordinate
 		 * @param directions The directions we're allowed to pass through
-		 * @returns value you can pass to cinnamon_global_destroy_pointer_barrier()
+		 * @returns value you can pass to {@link Cinnamon.Global.destroy_pointer_barrier}
 		 */
 		create_pointer_barrier(x1: number, y1: number, x2: number, y2: number, directions: number): number;
 		/**
-		 * Destroys the #barrier created by cinnamon_global_create_pointer_barrier().
+		 * Destroys the #barrier created by {@link Cinnamon.Global.create_pointer_barrier}.
 		 * @param barrier a pointer barrier
 		 */
 		destroy_pointer_barrier(barrier: number): void;
@@ -412,12 +412,12 @@ declare namespace imports.gi.Cinnamon {
 		 */
 		dump_gjs_stack(): void;
 		/**
-		 * Undoes the effect of cinnamon_global_begin_modal().
+		 * Undoes the effect of {@link Cinnamon.Global.begin_modal}.
 		 * @param timestamp
 		 */
 		end_modal(timestamp: number): void;
 		/**
-		 * Marks the end of work that we started with cinnamon_global_begin_work().
+		 * Marks the end of work that we started with {@link Cinnamon.Global.begin_work}.
 		 * If no other work is ongoing and functions have been added with
 		 * cinnamon_global_run_at_leisure(), they will be run at the next
 		 * opportunity.
@@ -430,7 +430,7 @@ declare namespace imports.gi.Cinnamon {
 		get_pid(): number;
 		/**
 		 * Gets the pointer coordinates and current modifier key state.
-		 * This is a wrapper around gdk_display_get_pointer() that strips
+		 * This is a wrapper around {@link Gdk.Display.get_pointer} that strips
 		 * out any un-declared modifier flags, to make gjs happy; see
 		 * https://bugzilla.gnome.org/show_bug.cgi?id=597292.
 		 * @returns the X coordinate of the pointer, in global coordinates
@@ -499,7 +499,7 @@ declare namespace imports.gi.Cinnamon {
 		set_cursor(type: Cursor): void;
 		/**
 		 * Sets the pointer coordinates.
-		 * This is a wrapper around gdk_device_warp().
+		 * This is a wrapper around {@link Gdk.Device.warp}.
 		 * @param x the X coordinate of the pointer, in global coordinates
 		 * @param y the Y coordinate of the pointer, in global coordinates
 		 */
@@ -510,7 +510,7 @@ declare namespace imports.gi.Cinnamon {
 		 * any clicks, but just passes them through to underlying windows.
 		 * When it is %CINNAMON_STAGE_INPUT_MODE_NORMAL, then the stage accepts
 		 * clicks in the region defined by
-		 * cinnamon_global_set_stage_input_region() but passes through clicks
+		 * {@link Cinnamon.Global.set_stage_input_region} but passes through clicks
 		 * outside that region. When it is %CINNAMON_STAGE_INPUT_MODE_FULLSCREEN,
 		 * the stage absorbs all input.
 		 * 
@@ -552,26 +552,26 @@ declare namespace imports.gi.Cinnamon {
 		connect(signal: "xdnd-leave", callback: (owner: this) => void): number;
 		connect(signal: "xdnd-position-changed", callback: (owner: this, object: number, p0: number) => void): number;
 
-		connect(signal: "notify::background_actor", callback: (owner: this, ...args: any) => number): number;
-		connect(signal: "notify::bottom_window_group", callback: (owner: this, ...args: any) => number): number;
-		connect(signal: "notify::datadir", callback: (owner: this, ...args: any) => number): number;
-		connect(signal: "notify::display", callback: (owner: this, ...args: any) => number): number;
-		connect(signal: "notify::focus_manager", callback: (owner: this, ...args: any) => number): number;
-		connect(signal: "notify::gdk_screen", callback: (owner: this, ...args: any) => number): number;
-		connect(signal: "notify::imagedir", callback: (owner: this, ...args: any) => number): number;
-		connect(signal: "notify::overlay_group", callback: (owner: this, ...args: any) => number): number;
-		connect(signal: "notify::screen", callback: (owner: this, ...args: any) => number): number;
-		connect(signal: "notify::screen_height", callback: (owner: this, ...args: any) => number): number;
-		connect(signal: "notify::screen_width", callback: (owner: this, ...args: any) => number): number;
-		connect(signal: "notify::session_running", callback: (owner: this, ...args: any) => number): number;
-		connect(signal: "notify::settings", callback: (owner: this, ...args: any) => number): number;
-		connect(signal: "notify::stage", callback: (owner: this, ...args: any) => number): number;
-		connect(signal: "notify::stage_input_mode", callback: (owner: this, ...args: any) => number): number;
-		connect(signal: "notify::top_window_group", callback: (owner: this, ...args: any) => number): number;
-		connect(signal: "notify::ui_scale", callback: (owner: this, ...args: any) => number): number;
-		connect(signal: "notify::userdatadir", callback: (owner: this, ...args: any) => number): number;
-		connect(signal: "notify::window_group", callback: (owner: this, ...args: any) => number): number;
-		connect(signal: "notify::window_manager", callback: (owner: this, ...args: any) => number): number;
+		connect(signal: "notify::background_actor", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::bottom_window_group", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::datadir", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::display", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::focus_manager", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gdk_screen", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::imagedir", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::overlay_group", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::screen", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::screen_height", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::screen_width", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::session_running", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::settings", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::stage", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::stage_input_mode", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::top_window_group", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::ui_scale", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::userdatadir", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::window_group", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::window_manager", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -623,7 +623,7 @@ declare namespace imports.gi.Cinnamon {
 	interface IGtkEmbed {
 		window: EmbeddedWindow;
 
-		connect(signal: "notify::window", callback: (owner: this, ...args: any) => number): number;
+		connect(signal: "notify::window", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -652,7 +652,7 @@ declare namespace imports.gi.Cinnamon {
 		/**
 		 * Adds a function that will be called before statistics are recorded.
 		 * The function would typically compute one or more statistics values
-		 * and call a function such as cinnamon_perf_log_update_statistic_i()
+		 * and call a function such as {@link Cinnamon.PerfLog.update_statistic_i}
 		 * to update the value that will be recorded.
 		 * @param callback function to call before recording statistics
 		 * @param notify function to call when #user_data is no longer needed
@@ -660,7 +660,7 @@ declare namespace imports.gi.Cinnamon {
 		add_statistics_callback(callback: PerfStatisticsCallback, notify: GLib.DestroyNotify): void;
 		/**
 		 * Calls all the update functions added with
-		 * cinnamon_perf_log_add_statistics_callback() and then records events
+		 * {@link Cinnamon.PerfLog.add_statistics_callback} and then records events
 		 * for all statistics, followed by a perf.statisticsCollected event.
 		 */
 		collect_statistics(): void;
@@ -681,7 +681,7 @@ declare namespace imports.gi.Cinnamon {
 		/**
 		 * Defines a statistic. A statistic is a numeric value that is stored
 		 * by the performance log and recorded periodically or when
-		 * cinnamon_perf_log_collect_statistics() is called explicitly.
+		 * {@link Cinnamon.PerfLog.collect_statistics} is called explicitly.
 		 * 
 		 * Code that defines a statistic should update it by calling
 		 * the update function for the particular data type of the statistic,
@@ -690,7 +690,7 @@ declare namespace imports.gi.Cinnamon {
 		 * with cinnamon_perf_log_add_statistics_callback(). These functions
 		 * are called immediately before statistics are recorded.
 		 * @param name name of the statistic and of the corresponding event.
-		 *  This should follow the same guidelines as for cinnamon_perf_log_define_event()
+		 *  This should follow the same guidelines as for {@link Cinnamon.PerfLog.define_event}
 		 * @param description human readable description of the statistic.
 		 * @param signature The type of the data stored for statistic. Must
 		 *  currently be 'i' or 'x'.
@@ -781,7 +781,7 @@ declare namespace imports.gi.Cinnamon {
 		public constructor(options?: Partial<PerfLogInitOptions>);
 		/**
 		 * Gets the global singleton performance log. This is initially disabled
-		 * and must be explicitly enabled with cinnamon_perf_log_set_enabled().
+		 * and must be explicitly enabled with {@link Cinnamon.PerfLog.set_enabled}.
 		 * @returns the global singleton performance log
 		 */
 		public static get_default(): PerfLog;
@@ -796,7 +796,7 @@ declare namespace imports.gi.Cinnamon {
 		pipeline: string;
 		stage: Clutter.Stage;
 		/**
-		 * Stops recording. It's possible to call cinnamon_recorder_record()
+		 * Stops recording. It's possible to call {@link Cinnamon.Recorder.record}
 		 * again to reopen a new recording stream, but unless change the
 		 * recording filename, this may result in the old recording being
 		 * overwritten.
@@ -812,7 +812,7 @@ declare namespace imports.gi.Cinnamon {
 		 * Temporarily stop recording. If the specified filename includes
 		 * the %c escape, then the stream is closed and a new stream with
 		 * an incremented counter will be created. Otherwise the stream
-		 * is paused and will be continued when cinnamon_recorder_record()
+		 * is paused and will be continued when {@link Cinnamon.Recorder.record}
 		 * is next called.
 		 */
 		pause(): void;
@@ -866,7 +866,7 @@ declare namespace imports.gi.Cinnamon {
 		 * should have an unconnected sink pad where the recorded
 		 * video is recorded. It will normally have a unconnected
 		 * source pad; output from that pad will be written into the
-		 * output file. (See cinnamon_recorder_set_filename().) However
+		 * output file. (See {@link Cinnamon.Recorder.set_filename}.) However
 		 * the pipeline can also take care of its own output - this
 		 * might be used to send the output to an icecast server
 		 * via shout2send or similar.
@@ -876,10 +876,10 @@ declare namespace imports.gi.Cinnamon {
 		 *            or %NULL for the default value.
 		 */
 		set_pipeline(pipeline: string | null): void;
-		connect(signal: "notify::filename", callback: (owner: this, ...args: any) => number): number;
-		connect(signal: "notify::framerate", callback: (owner: this, ...args: any) => number): number;
-		connect(signal: "notify::pipeline", callback: (owner: this, ...args: any) => number): number;
-		connect(signal: "notify::stage", callback: (owner: this, ...args: any) => number): number;
+		connect(signal: "notify::filename", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::framerate", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::pipeline", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::stage", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -1019,9 +1019,9 @@ declare namespace imports.gi.Cinnamon {
 		 * @param event the #ClutterEvent triggering the fake click
 		 */
 		click(event: Clutter.Event): void;
-		connect(signal: "notify::pid", callback: (owner: this, ...args: any) => number): number;
-		connect(signal: "notify::title", callback: (owner: this, ...args: any) => number): number;
-		connect(signal: "notify::wm_class", callback: (owner: this, ...args: any) => number): number;
+		connect(signal: "notify::pid", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::title", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::wm_class", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -1056,7 +1056,7 @@ declare namespace imports.gi.Cinnamon {
 		connect(signal: "tray-icon-added", callback: (owner: this, object: Clutter.Actor) => void): number;
 		connect(signal: "tray-icon-removed", callback: (owner: this, object: Clutter.Actor) => void): number;
 
-		connect(signal: "notify::bg_color", callback: (owner: this, ...args: any) => number): number;
+		connect(signal: "notify::bg_color", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -1184,7 +1184,7 @@ declare namespace imports.gi.Cinnamon {
 		connect(signal: "startup-sequence-changed", callback: (owner: this, object: StartupSequence) => void): number;
 		connect(signal: "window-app-changed", callback: (owner: this, object: Meta.Window) => void): number;
 
-		connect(signal: "notify::focus_app", callback: (owner: this, ...args: any) => number): number;
+		connect(signal: "notify::focus_app", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -1224,7 +1224,7 @@ declare namespace imports.gi.Cinnamon {
 		update_texture_image(texture: Clutter.Texture): void;
 		connect(signal: "cursor-change", callback: (owner: this) => void): number;
 
-		connect(signal: "notify::stage", callback: (owner: this, ...args: any) => number): number;
+		connect(signal: "notify::stage", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -1246,56 +1246,6 @@ declare namespace imports.gi.Cinnamon {
 		public static get_for_stage(stage: Clutter.Stage): XFixesCursor;
 	}
 
-	export interface AppClassInitOptions {}
-	interface AppClass {}
-	class AppClass {
-		public constructor(options?: Partial<AppClassInitOptions>);
-	}
-
-	export interface AppPrivateInitOptions {}
-	interface AppPrivate {}
-	class AppPrivate {
-		public constructor(options?: Partial<AppPrivateInitOptions>);
-	}
-
-	export interface AppSystemClassInitOptions {}
-	interface AppSystemClass {}
-	class AppSystemClass {
-		public constructor(options?: Partial<AppSystemClassInitOptions>);
-		public installed_changed: {(appsys: AppSystem): void;};
-		public favorites_changed: {(appsys: AppSystem): void;};
-	}
-
-	export interface AppSystemPrivateInitOptions {}
-	interface AppSystemPrivate {}
-	class AppSystemPrivate {
-		public constructor(options?: Partial<AppSystemPrivateInitOptions>);
-	}
-
-	export interface DocSystemClassInitOptions {}
-	interface DocSystemClass {}
-	class DocSystemClass {
-		public constructor(options?: Partial<DocSystemClassInitOptions>);
-	}
-
-	export interface DocSystemPrivateInitOptions {}
-	interface DocSystemPrivate {}
-	class DocSystemPrivate {
-		public constructor(options?: Partial<DocSystemPrivateInitOptions>);
-	}
-
-	export interface EmbeddedWindowClassInitOptions {}
-	interface EmbeddedWindowClass {}
-	class EmbeddedWindowClass {
-		public constructor(options?: Partial<EmbeddedWindowClassInitOptions>);
-	}
-
-	export interface EmbeddedWindowPrivateInitOptions {}
-	interface EmbeddedWindowPrivate {}
-	class EmbeddedWindowPrivate {
-		public constructor(options?: Partial<EmbeddedWindowPrivateInitOptions>);
-	}
-
 	export interface GenericContainerAllocationInitOptions {}
 	interface GenericContainerAllocation {}
 	class GenericContainerAllocation {
@@ -1303,78 +1253,6 @@ declare namespace imports.gi.Cinnamon {
 		public min_size: number;
 		public natural_size: number;
 		public readonly _refcount: number;
-	}
-
-	export interface GenericContainerClassInitOptions {}
-	interface GenericContainerClass {}
-	class GenericContainerClass {
-		public constructor(options?: Partial<GenericContainerClassInitOptions>);
-	}
-
-	export interface GenericContainerPrivateInitOptions {}
-	interface GenericContainerPrivate {}
-	class GenericContainerPrivate {
-		public constructor(options?: Partial<GenericContainerPrivateInitOptions>);
-	}
-
-	export interface GlobalClassInitOptions {}
-	interface GlobalClass {}
-	class GlobalClass {
-		public constructor(options?: Partial<GlobalClassInitOptions>);
-	}
-
-	export interface GtkEmbedClassInitOptions {}
-	interface GtkEmbedClass {}
-	class GtkEmbedClass {
-		public constructor(options?: Partial<GtkEmbedClassInitOptions>);
-	}
-
-	export interface GtkEmbedPrivateInitOptions {}
-	interface GtkEmbedPrivate {}
-	class GtkEmbedPrivate {
-		public constructor(options?: Partial<GtkEmbedPrivateInitOptions>);
-	}
-
-	export interface PerfLogClassInitOptions {}
-	interface PerfLogClass {}
-	class PerfLogClass {
-		public constructor(options?: Partial<PerfLogClassInitOptions>);
-	}
-
-	export interface RecorderClassInitOptions {}
-	interface RecorderClass {}
-	class RecorderClass {
-		public constructor(options?: Partial<RecorderClassInitOptions>);
-	}
-
-	export interface ScreenshotClassInitOptions {}
-	interface ScreenshotClass {}
-	class ScreenshotClass {
-		public constructor(options?: Partial<ScreenshotClassInitOptions>);
-	}
-
-	export interface SlicerClassInitOptions {}
-	interface SlicerClass {}
-	class SlicerClass {
-		public constructor(options?: Partial<SlicerClassInitOptions>);
-	}
-
-	export interface SlicerPrivateInitOptions {}
-	interface SlicerPrivate {}
-	class SlicerPrivate {
-		public constructor(options?: Partial<SlicerPrivateInitOptions>);
-	}
-
-	export interface StackClassInitOptions {}
-	interface StackClass {}
-	class StackClass {
-		public constructor(options?: Partial<StackClassInitOptions>);
-	}
-
-	export interface StackPrivateInitOptions {}
-	interface StackPrivate {}
-	class StackPrivate {
-		public constructor(options?: Partial<StackPrivateInitOptions>);
 	}
 
 	export interface StartupSequenceInitOptions {}
@@ -1386,56 +1264,6 @@ declare namespace imports.gi.Cinnamon {
 		public get_completed(): boolean;
 		public get_id(): string;
 		public get_name(): string;
-	}
-
-	export interface TrayIconClassInitOptions {}
-	interface TrayIconClass {}
-	class TrayIconClass {
-		public constructor(options?: Partial<TrayIconClassInitOptions>);
-	}
-
-	export interface TrayIconPrivateInitOptions {}
-	interface TrayIconPrivate {}
-	class TrayIconPrivate {
-		public constructor(options?: Partial<TrayIconPrivateInitOptions>);
-	}
-
-	export interface TrayManagerClassInitOptions {}
-	interface TrayManagerClass {}
-	class TrayManagerClass {
-		public constructor(options?: Partial<TrayManagerClassInitOptions>);
-		public tray_icon_added: {(manager: TrayManager, icon: Clutter.Actor, lowercase_wm_class: string): void;};
-		public tray_icon_removed: {(manager: TrayManager, icon: Clutter.Actor): void;};
-	}
-
-	export interface TrayManagerPrivateInitOptions {}
-	interface TrayManagerPrivate {}
-	class TrayManagerPrivate {
-		public constructor(options?: Partial<TrayManagerPrivateInitOptions>);
-	}
-
-	export interface WMClassInitOptions {}
-	interface WMClass {}
-	class WMClass {
-		public constructor(options?: Partial<WMClassInitOptions>);
-	}
-
-	export interface WindowTrackerClassInitOptions {}
-	interface WindowTrackerClass {}
-	class WindowTrackerClass {
-		public constructor(options?: Partial<WindowTrackerClassInitOptions>);
-	}
-
-	export interface WindowTrackerPrivateInitOptions {}
-	interface WindowTrackerPrivate {}
-	class WindowTrackerPrivate {
-		public constructor(options?: Partial<WindowTrackerPrivateInitOptions>);
-	}
-
-	export interface XFixesCursorClassInitOptions {}
-	interface XFixesCursorClass {}
-	class XFixesCursorClass {
-		public constructor(options?: Partial<XFixesCursorClassInitOptions>);
 	}
 
 	enum AppState {
@@ -1470,11 +1298,11 @@ declare namespace imports.gi.Cinnamon {
 	}
 
 	/**
-	 * Callback type for cinnamon_get_file_contents_utf8()
+	 * Callback type for {@link Cinnamon.get.file_contents_utf8}
 	 */
 	interface FileContentsCallback {
 		/**
-		 * Callback type for cinnamon_get_file_contents_utf8()
+		 * Callback type for {@link Cinnamon.get.file_contents_utf8}
 		 * @param utf8_contents The contents of the file
 		 */
 		(utf8_contents: string): void;
@@ -1497,7 +1325,7 @@ declare namespace imports.gi.Cinnamon {
 	}
 
 	/**
-	 * Using G_BREAKPOINT(), interrupt the current process.  This is useful
+	 * Using {@link G.BREAKPOINT}, interrupt the current process.  This is useful
 	 * in conjunction with a debugger such as gdb.
 	 */
 	function breakpoint(): void;
@@ -1505,7 +1333,7 @@ declare namespace imports.gi.Cinnamon {
 	/**
 	 * Gets the current state of the event (the set of modifier keys that
 	 * are pressed down). Thhis is a wrapper around
-	 * clutter_event_get_state() that strips out any un-declared modifier
+	 * {@link Clutter.event.get_state} that strips out any un-declared modifier
 	 * flags, to make gjs happy; see
 	 * https://bugzilla.gnome.org/show_bug.cgi?id=597292.
 	 * @param event a #ClutterEvent
@@ -1554,7 +1382,7 @@ declare namespace imports.gi.Cinnamon {
 	 * Unicode format strings:
 	 * https://bugzilla.mozilla.org/show_bug.cgi?id=508783
 	 * @param format a strftime-style string format, as parsed by
-	 *   g_date_time_format()
+	 *   {@link Glib.date_time_format}
 	 * @param time_ms milliseconds since 1970-01-01 00:00:00 UTC; the
 	 *   value returned by Date.getTime()
 	 * @returns the formatted date. If the date is
@@ -1575,7 +1403,7 @@ declare namespace imports.gi.Cinnamon {
 	function util_get_label_for_uri(text_uri: string): string;
 
 	/**
-	 * This function is similar to a combination of clutter_actor_get_transformed_position(),
+	 * This function is similar to a combination of {@link Clutter.Actor.get_transformed_position},
 	 * and clutter_actor_get_transformed_size(), but unlike
 	 * clutter_actor_get_transformed_size(), it always returns a transform
 	 * of the current allocation, while clutter_actor_get_transformed_size() returns

--- a/CinnamonDesktop-3.0.d.ts
+++ b/CinnamonDesktop-3.0.d.ts
@@ -80,7 +80,7 @@ declare namespace imports.gi.CinnamonDesktop {
 		 * we won't leak the pixmap if somebody else it setting
 		 * it at the same time. (This assumes that they follow the
 		 * same conventions we do).  #surface should come from a call
-		 * to gnome_bg_create_surface().
+		 * to {@link Gnome.bg_create_surface}.
 		 * @param screen the #GdkScreen to change root background on
 		 * @param surface the #cairo_surface_t to set root background from.
 		 *   Must be an xlib surface backing a pixmap.
@@ -88,7 +88,7 @@ declare namespace imports.gi.CinnamonDesktop {
 		public static set_surface_as_root(screen: Gdk.Screen, surface: cairo.Surface): void;
 		/**
 		 * Set the root pixmap, and properties pointing to it.
-		 * This function differs from gnome_bg_set_surface_as_root()
+		 * This function differs from {@link Gnome.bg_set_surface_as_root}
 		 * in that it adds a subtle crossfade animation from the
 		 * current root pixmap to the new one.
 		 * @param screen the #GdkScreen to change root background on
@@ -115,13 +115,13 @@ declare namespace imports.gi.CinnamonDesktop {
 		readonly parent_object: GObject.Object;
 		/**
 		 * This function reveals whether or not #fade is currently
-		 * running on a window.  See gnome_bg_crossfade_start() for
+		 * running on a window.  See {@link Gnome.bg_crossfade_start} for
 		 * information on how to initiate a crossfade.
 		 * @returns %TRUE if fading, or %FALSE if not fading
 		 */
 		is_started(): boolean;
 		/**
-		 * Before initiating a crossfade with gnome_bg_crossfade_start()
+		 * Before initiating a crossfade with {@link Gnome.bg_crossfade_start}
 		 * a start and end surface have to be set.  This function sets
 		 * the surface shown at the end of the crossfade effect.
 		 * @param surface The cairo surface to fade to
@@ -130,7 +130,7 @@ declare namespace imports.gi.CinnamonDesktop {
 		 */
 		set_end_surface(surface: cairo.Surface): boolean;
 		/**
-		 * Before initiating a crossfade with gnome_bg_crossfade_start()
+		 * Before initiating a crossfade with {@link Gnome.bg_crossfade_start}
 		 * a start and end surface have to be set.  This function sets
 		 * the surface shown at the beginning of the crossfade effect.
 		 * @param surface The cairo surface to fade from
@@ -141,7 +141,7 @@ declare namespace imports.gi.CinnamonDesktop {
 		/**
 		 * This function initiates a quick crossfade between two surfaces on
 		 * the background of #window.  Before initiating the crossfade both
-		 * gnome_bg_crossfade_start() and gnome_bg_crossfade_end() need to
+		 * {@link Gnome.bg_crossfade_start} and gnome_bg_crossfade_end() need to
 		 * be called. If animations are disabled, the crossfade is skipped,
 		 * and the window background is set immediately to the end surface.
 		 * @param window The #GdkWindow to draw crossfade on
@@ -166,9 +166,9 @@ declare namespace imports.gi.CinnamonDesktop {
 		 */
 		connect(signal: "finished", callback: (owner: this, window: GObject.Object) => void): number;
 
-		connect(signal: "notify::height", callback: (owner: this, ...args: any) => number): number;
-		connect(signal: "notify::width", callback: (owner: this, ...args: any) => number): number;
-		connect(signal: "notify::parent_object", callback: (owner: this, ...args: any) => number): number;
+		connect(signal: "notify::height", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::width", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::parent_object", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -570,7 +570,7 @@ declare namespace imports.gi.CinnamonDesktop {
 		 */
 		connect(signal: "output-disconnected", callback: (owner: this, output: any | null) => void): number;
 
-		connect(signal: "notify::gdk_screen", callback: (owner: this, ...args: any) => number): number;
+		connect(signal: "notify::gdk_screen", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -653,9 +653,9 @@ declare namespace imports.gi.CinnamonDesktop {
 		 * @returns Whether or not the format string was valid and accepted.
 		 */
 		set_format_string(format_string: string | null): boolean;
-		connect(signal: "notify::clock", callback: (owner: this, ...args: any) => number): number;
-		connect(signal: "notify::format_string", callback: (owner: this, ...args: any) => number): number;
-		connect(signal: "notify::parent_object", callback: (owner: this, ...args: any) => number): number;
+		connect(signal: "notify::clock", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::format_string", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::parent_object", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -742,7 +742,7 @@ declare namespace imports.gi.CinnamonDesktop {
 		get_layout_info(id: string): [ boolean, string | null, string | null, string | null, string | null ];
 		/**
 		 * Retrieves the layout that better fits #language. It also fetches
-		 * information about that layout like gnome_xkb_info_get_layout_info().
+		 * information about that layout like {@link Gnome.xkb_info_get_layout_info}.
 		 * 
 		 * If a layout can't be found the return value is %FALSE and all the
 		 * (out) parameters are set to %NULL.
@@ -775,7 +775,7 @@ declare namespace imports.gi.CinnamonDesktop {
 		 * be modified.
 		 */
 		get_options_for_group(group_id: string): GLib.List;
-		connect(signal: "notify::parent_object", callback: (owner: this, ...args: any) => number): number;
+		connect(signal: "notify::parent_object", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -797,7 +797,7 @@ declare namespace imports.gi.CinnamonDesktop {
 		public static new(): XkbInfo;
 		/**
 		 * Frees an #XkbRF_VarDefsRec instance allocated by
-		 * gnome_xkb_info_get_var_defs().
+		 * {@link Gnome.xkb_info_get_var_defs}.
 		 * @param var_defs #XkbRF_VarDefsRec instance to free
 		 */
 		public static free_var_defs(var_defs: any): void;
@@ -805,68 +805,13 @@ declare namespace imports.gi.CinnamonDesktop {
 		 * Gets both the XKB rules file path and the current XKB parameters in
 		 * use by the X server.
 		 * @returns location to store the rules file
-		 * path. Use g_free() when it's no longer needed
+		 * path. Use {@link GObject.free} when it's no longer needed
 		 * 
 		 * location to store a
 		 * #XkbRF_VarDefsRec pointer. Use gnome_xkb_info_free_var_defs() to
 		 * free it
 		 */
 		public static get_var_defs(): [ rules: string, var_defs: any ];
-	}
-
-	export interface BGClassInitOptions {}
-	interface BGClass {}
-	class BGClass {
-		public constructor(options?: Partial<BGClassInitOptions>);
-	}
-
-	export interface BGCrossfadeClassInitOptions {}
-	interface BGCrossfadeClass {}
-	class BGCrossfadeClass {
-		public constructor(options?: Partial<BGCrossfadeClassInitOptions>);
-		public finished: {(fade: BGCrossfade, window: Gdk.Window): void;};
-	}
-
-	export interface BGCrossfadePrivateInitOptions {}
-	interface BGCrossfadePrivate {}
-	class BGCrossfadePrivate {
-		public constructor(options?: Partial<BGCrossfadePrivateInitOptions>);
-	}
-
-	export interface DesktopThumbnailFactoryClassInitOptions {}
-	interface DesktopThumbnailFactoryClass {}
-	class DesktopThumbnailFactoryClass {
-		public constructor(options?: Partial<DesktopThumbnailFactoryClassInitOptions>);
-	}
-
-	export interface DesktopThumbnailFactoryPrivateInitOptions {}
-	interface DesktopThumbnailFactoryPrivate {}
-	class DesktopThumbnailFactoryPrivate {
-		public constructor(options?: Partial<DesktopThumbnailFactoryPrivateInitOptions>);
-	}
-
-	export interface PnpIdsClassInitOptions {}
-	interface PnpIdsClass {}
-	class PnpIdsClass {
-		public constructor(options?: Partial<PnpIdsClassInitOptions>);
-	}
-
-	export interface PnpIdsPrivateInitOptions {}
-	interface PnpIdsPrivate {}
-	class PnpIdsPrivate {
-		public constructor(options?: Partial<PnpIdsPrivateInitOptions>);
-	}
-
-	export interface RRConfigClassInitOptions {}
-	interface RRConfigClass {}
-	class RRConfigClass {
-		public constructor(options?: Partial<RRConfigClassInitOptions>);
-	}
-
-	export interface RRConfigPrivateInitOptions {}
-	interface RRConfigPrivate {}
-	class RRConfigPrivate {
-		public constructor(options?: Partial<RRConfigPrivateInitOptions>);
 	}
 
 	export interface RRCrtcInitOptions {}
@@ -884,18 +829,6 @@ declare namespace imports.gi.CinnamonDesktop {
 		public set_config_with_time(timestamp: number, x: number, y: number, mode: RRMode, rotation: RRRotation, outputs: RROutput, n_outputs: number, scale: number, global_scale: number): boolean;
 		public set_gamma(size: number, red: number, green: number, blue: number): void;
 		public supports_rotation(rotation: RRRotation): boolean;
-	}
-
-	export interface RRLabelerClassInitOptions {}
-	interface RRLabelerClass {}
-	class RRLabelerClass {
-		public constructor(options?: Partial<RRLabelerClassInitOptions>);
-	}
-
-	export interface RRLabelerPrivateInitOptions {}
-	interface RRLabelerPrivate {}
-	class RRLabelerPrivate {
-		public constructor(options?: Partial<RRLabelerPrivateInitOptions>);
 	}
 
 	export interface RRModeInitOptions {}
@@ -937,57 +870,6 @@ declare namespace imports.gi.CinnamonDesktop {
 		public list_modes(): RRMode;
 		public set_backlight(value: number): boolean;
 		public supports_mode(mode: RRMode): boolean;
-	}
-
-	export interface RROutputInfoClassInitOptions {}
-	interface RROutputInfoClass {}
-	class RROutputInfoClass {
-		public constructor(options?: Partial<RROutputInfoClassInitOptions>);
-	}
-
-	export interface RROutputInfoPrivateInitOptions {}
-	interface RROutputInfoPrivate {}
-	class RROutputInfoPrivate {
-		public constructor(options?: Partial<RROutputInfoPrivateInitOptions>);
-	}
-
-	export interface RRScreenClassInitOptions {}
-	interface RRScreenClass {}
-	class RRScreenClass {
-		public constructor(options?: Partial<RRScreenClassInitOptions>);
-		public changed: {(): void;};
-		public output_connected: {(output: RROutput): void;};
-		public output_disconnected: {(output: RROutput): void;};
-	}
-
-	export interface RRScreenPrivateInitOptions {}
-	interface RRScreenPrivate {}
-	class RRScreenPrivate {
-		public constructor(options?: Partial<RRScreenPrivateInitOptions>);
-	}
-
-	export interface WallClockClassInitOptions {}
-	interface WallClockClass {}
-	class WallClockClass {
-		public constructor(options?: Partial<WallClockClassInitOptions>);
-	}
-
-	export interface WallClockPrivateInitOptions {}
-	interface WallClockPrivate {}
-	class WallClockPrivate {
-		public constructor(options?: Partial<WallClockPrivateInitOptions>);
-	}
-
-	export interface XkbInfoClassInitOptions {}
-	interface XkbInfoClass {}
-	class XkbInfoClass {
-		public constructor(options?: Partial<XkbInfoClassInitOptions>);
-	}
-
-	export interface XkbInfoPrivateInitOptions {}
-	interface XkbInfoPrivate {}
-	class XkbInfoPrivate {
-		public constructor(options?: Partial<XkbInfoPrivateInitOptions>);
 	}
 
 	enum DesktopThumbnailSize {

--- a/Cvc-1.0.d.ts
+++ b/Cvc-1.0.d.ts
@@ -61,13 +61,13 @@ declare namespace imports.gi.Cvc {
 		set_ports(ports: GLib.List): boolean;
 		set_profile(profile: string): boolean;
 		set_profiles(profiles: GLib.List): boolean;
-		connect(signal: "notify::human_profile", callback: (owner: this, ...args: any) => number): number;
-		connect(signal: "notify::icon_name", callback: (owner: this, ...args: any) => number): number;
-		connect(signal: "notify::id", callback: (owner: this, ...args: any) => number): number;
-		connect(signal: "notify::index", callback: (owner: this, ...args: any) => number): number;
-		connect(signal: "notify::name", callback: (owner: this, ...args: any) => number): number;
-		connect(signal: "notify::pa_context", callback: (owner: this, ...args: any) => number): number;
-		connect(signal: "notify::profile", callback: (owner: this, ...args: any) => number): number;
+		connect(signal: "notify::human_profile", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::icon_name", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::id", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::index", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::name", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::pa_context", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::profile", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -141,7 +141,7 @@ declare namespace imports.gi.Cvc {
 		connect(signal: "stream-changed", callback: (owner: this, object: number) => void): number;
 		connect(signal: "stream-removed", callback: (owner: this, object: number) => void): number;
 
-		connect(signal: "notify::name", callback: (owner: this, ...args: any) => number): number;
+		connect(signal: "notify::name", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -169,7 +169,7 @@ declare namespace imports.gi.Cvc {
 	interface IMixerEventRole {
 		device: string;
 
-		connect(signal: "notify::device", callback: (owner: this, ...args: any) => number): number;
+		connect(signal: "notify::device", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -346,24 +346,24 @@ declare namespace imports.gi.Cvc {
 		connect(signal: "monitor-suspend", callback: (owner: this) => void): number;
 		connect(signal: "monitor-update", callback: (owner: this, object: number) => void): number;
 
-		connect(signal: "notify::application_id", callback: (owner: this, ...args: any) => number): number;
-		connect(signal: "notify::can_decibel", callback: (owner: this, ...args: any) => number): number;
-		connect(signal: "notify::card_index", callback: (owner: this, ...args: any) => number): number;
-		connect(signal: "notify::channel_map", callback: (owner: this, ...args: any) => number): number;
-		connect(signal: "notify::decibel", callback: (owner: this, ...args: any) => number): number;
-		connect(signal: "notify::description", callback: (owner: this, ...args: any) => number): number;
-		connect(signal: "notify::form_factor", callback: (owner: this, ...args: any) => number): number;
-		connect(signal: "notify::icon_name", callback: (owner: this, ...args: any) => number): number;
-		connect(signal: "notify::id", callback: (owner: this, ...args: any) => number): number;
-		connect(signal: "notify::index", callback: (owner: this, ...args: any) => number): number;
-		connect(signal: "notify::is_event_stream", callback: (owner: this, ...args: any) => number): number;
-		connect(signal: "notify::is_muted", callback: (owner: this, ...args: any) => number): number;
-		connect(signal: "notify::is_virtual", callback: (owner: this, ...args: any) => number): number;
-		connect(signal: "notify::name", callback: (owner: this, ...args: any) => number): number;
-		connect(signal: "notify::pa_context", callback: (owner: this, ...args: any) => number): number;
-		connect(signal: "notify::port", callback: (owner: this, ...args: any) => number): number;
-		connect(signal: "notify::sysfs_path", callback: (owner: this, ...args: any) => number): number;
-		connect(signal: "notify::volume", callback: (owner: this, ...args: any) => number): number;
+		connect(signal: "notify::application_id", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::can_decibel", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::card_index", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::channel_map", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::decibel", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::description", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::form_factor", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::icon_name", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::id", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::index", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::is_event_stream", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::is_muted", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::is_virtual", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::name", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::pa_context", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::port", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::sysfs_path", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::volume", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -455,14 +455,14 @@ declare namespace imports.gi.Cvc {
 		set_profiles(in_profiles: GLib.List): void;
 		set_user_preferred_profile(profile: string): void;
 		should_profiles_be_hidden(): boolean;
-		connect(signal: "notify::card", callback: (owner: this, ...args: any) => number): number;
-		connect(signal: "notify::description", callback: (owner: this, ...args: any) => number): number;
-		connect(signal: "notify::icon_name", callback: (owner: this, ...args: any) => number): number;
-		connect(signal: "notify::origin", callback: (owner: this, ...args: any) => number): number;
-		connect(signal: "notify::port_available", callback: (owner: this, ...args: any) => number): number;
-		connect(signal: "notify::port_name", callback: (owner: this, ...args: any) => number): number;
-		connect(signal: "notify::stream_id", callback: (owner: this, ...args: any) => number): number;
-		connect(signal: "notify::type", callback: (owner: this, ...args: any) => number): number;
+		connect(signal: "notify::card", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::description", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::icon_name", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::origin", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::port_available", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::port_name", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::stream_id", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::type", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -490,25 +490,6 @@ declare namespace imports.gi.Cvc {
 		public constructor(options?: Partial<MixerUIDeviceInitOptions>);
 	}
 
-	export interface ChannelMapClassInitOptions {}
-	interface ChannelMapClass {}
-	class ChannelMapClass {
-		public constructor(options?: Partial<ChannelMapClassInitOptions>);
-		public volume_changed: {(channel_map: ChannelMap, set: boolean): void;};
-	}
-
-	export interface ChannelMapPrivateInitOptions {}
-	interface ChannelMapPrivate {}
-	class ChannelMapPrivate {
-		public constructor(options?: Partial<ChannelMapPrivateInitOptions>);
-	}
-
-	export interface MixerCardClassInitOptions {}
-	interface MixerCardClass {}
-	class MixerCardClass {
-		public constructor(options?: Partial<MixerCardClassInitOptions>);
-	}
-
 	export interface MixerCardPortInitOptions {}
 	interface MixerCardPort {}
 	class MixerCardPort {
@@ -520,12 +501,6 @@ declare namespace imports.gi.Cvc {
 		public available: number;
 		public direction: number;
 		public profiles: GLib.List;
-	}
-
-	export interface MixerCardPrivateInitOptions {}
-	interface MixerCardPrivate {}
-	class MixerCardPrivate {
-		public constructor(options?: Partial<MixerCardPrivateInitOptions>);
 	}
 
 	export interface MixerCardProfileInitOptions {}
@@ -541,104 +516,6 @@ declare namespace imports.gi.Cvc {
 		public compare(b: MixerCardProfile): number;
 	}
 
-	export interface MixerControlClassInitOptions {}
-	interface MixerControlClass {}
-	class MixerControlClass {
-		public constructor(options?: Partial<MixerControlClassInitOptions>);
-		public state_changed: {(control: MixerControl, new_state: MixerControlState): void;};
-		public stream_added: {(control: MixerControl, id: number): void;};
-		public stream_changed: {(control: MixerControl, id: number): void;};
-		public stream_removed: {(control: MixerControl, id: number): void;};
-		public card_added: {(control: MixerControl, id: number): void;};
-		public card_removed: {(control: MixerControl, id: number): void;};
-		public default_sink_changed: {(control: MixerControl, id: number): void;};
-		public default_source_changed: {(control: MixerControl, id: number): void;};
-		public active_output_update: {(control: MixerControl, id: number): void;};
-		public active_input_update: {(control: MixerControl, id: number): void;};
-		public output_added: {(control: MixerControl, id: number): void;};
-		public input_added: {(control: MixerControl, id: number): void;};
-		public output_removed: {(control: MixerControl, id: number): void;};
-		public input_removed: {(control: MixerControl, id: number): void;};
-		public audio_device_selection_needed: {(control: MixerControl, id: number, show_dialog: boolean, choices: HeadsetPortChoice): void;};
-	}
-
-	export interface MixerControlPrivateInitOptions {}
-	interface MixerControlPrivate {}
-	class MixerControlPrivate {
-		public constructor(options?: Partial<MixerControlPrivateInitOptions>);
-	}
-
-	export interface MixerEventRoleClassInitOptions {}
-	interface MixerEventRoleClass {}
-	class MixerEventRoleClass {
-		public constructor(options?: Partial<MixerEventRoleClassInitOptions>);
-	}
-
-	export interface MixerEventRolePrivateInitOptions {}
-	interface MixerEventRolePrivate {}
-	class MixerEventRolePrivate {
-		public constructor(options?: Partial<MixerEventRolePrivateInitOptions>);
-	}
-
-	export interface MixerSinkClassInitOptions {}
-	interface MixerSinkClass {}
-	class MixerSinkClass {
-		public constructor(options?: Partial<MixerSinkClassInitOptions>);
-	}
-
-	export interface MixerSinkInputClassInitOptions {}
-	interface MixerSinkInputClass {}
-	class MixerSinkInputClass {
-		public constructor(options?: Partial<MixerSinkInputClassInitOptions>);
-	}
-
-	export interface MixerSinkInputPrivateInitOptions {}
-	interface MixerSinkInputPrivate {}
-	class MixerSinkInputPrivate {
-		public constructor(options?: Partial<MixerSinkInputPrivateInitOptions>);
-	}
-
-	export interface MixerSinkPrivateInitOptions {}
-	interface MixerSinkPrivate {}
-	class MixerSinkPrivate {
-		public constructor(options?: Partial<MixerSinkPrivateInitOptions>);
-	}
-
-	export interface MixerSourceClassInitOptions {}
-	interface MixerSourceClass {}
-	class MixerSourceClass {
-		public constructor(options?: Partial<MixerSourceClassInitOptions>);
-	}
-
-	export interface MixerSourceOutputClassInitOptions {}
-	interface MixerSourceOutputClass {}
-	class MixerSourceOutputClass {
-		public constructor(options?: Partial<MixerSourceOutputClassInitOptions>);
-	}
-
-	export interface MixerSourceOutputPrivateInitOptions {}
-	interface MixerSourceOutputPrivate {}
-	class MixerSourceOutputPrivate {
-		public constructor(options?: Partial<MixerSourceOutputPrivateInitOptions>);
-	}
-
-	export interface MixerSourcePrivateInitOptions {}
-	interface MixerSourcePrivate {}
-	class MixerSourcePrivate {
-		public constructor(options?: Partial<MixerSourcePrivateInitOptions>);
-	}
-
-	export interface MixerStreamClassInitOptions {}
-	interface MixerStreamClass {}
-	class MixerStreamClass {
-		public constructor(options?: Partial<MixerStreamClassInitOptions>);
-		public push_volume: {(stream: MixerStream, operation: any | null): boolean;};
-		public change_is_muted: {(stream: MixerStream, is_muted: boolean): boolean;};
-		public change_port: {(stream: MixerStream, port: string): boolean;};
-		public monitor_update: {(stream: MixerStream, v: number): void;};
-		public monitor_suspend: {(stream: MixerStream): void;};
-	}
-
 	export interface MixerStreamPortInitOptions {}
 	interface MixerStreamPort {}
 	class MixerStreamPort {
@@ -647,24 +524,6 @@ declare namespace imports.gi.Cvc {
 		public human_port: string;
 		public priority: number;
 		public available: boolean;
-	}
-
-	export interface MixerStreamPrivateInitOptions {}
-	interface MixerStreamPrivate {}
-	class MixerStreamPrivate {
-		public constructor(options?: Partial<MixerStreamPrivateInitOptions>);
-	}
-
-	export interface MixerUIDeviceClassInitOptions {}
-	interface MixerUIDeviceClass {}
-	class MixerUIDeviceClass {
-		public constructor(options?: Partial<MixerUIDeviceClassInitOptions>);
-	}
-
-	export interface MixerUIDevicePrivateInitOptions {}
-	interface MixerUIDevicePrivate {}
-	class MixerUIDevicePrivate {
-		public constructor(options?: Partial<MixerUIDevicePrivateInitOptions>);
 	}
 
 	enum MixerControlState {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ci-types/cjs",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "Typescript declarations for CJS - Cinnamon JavaScript",
   "types": "index.d.ts",
   "scripts": {


### PR DESCRIPTION
@Gr3q you didn't update the return type for notify-callbacks in this repo. The radio applet however is using one notify from the CVC file. So I copied the types from your GIR2TS repo. This updates all files which have at least one `notify::prop` event. 