### PR TITLE
update global.d.ts

### DIFF
--- a/cinnamon/globals.d.ts
+++ b/cinnamon/globals.d.ts
@@ -36,13 +36,18 @@ declare interface Global {
     set_pointer(x: number, y: number): void
     focus_manager: imports.gi.St.FocusManager
 
+    /**
+     * @returns the current X server time from the current Clutter, Gdk, or X event. If called from outside an event handler, this may return Clutter.CURRENT_TIME (aka 0), or it may return a slightly out-of-date timestamp.
+     */
+    get_current_time(): number
+
     ui_scale: number;
     /** the directory, the cinnamon spices are placed, e.g. on Linux Mint 20.2 this is: $HOME/.local/share/cinnamon  */
     userdatadir: string
 
     stage_input_mode: imports.gi.Cinnamon.StageInputMode;
 
-    reparentActor(actor_before: imports.gi.Clutter.Actor, actor_after: imports.gi.Clutter.Actor): void
+    reparentActor: typeof imports.ui.main['_reparentActor']
 }
 
 declare const global: Global;
@@ -110,14 +115,15 @@ declare namespace imports.gettext {
 }
 
 declare namespace imports {
+
     export const lang: Lang;
-    class Lang {
+    interface Lang {
         bind<T, CTX>(ctx: CTX, func: T): T;
     }
 
     export const signals: Signals
 
-    class Signals {
+    interface Signals {
         addSignalMethods(prototype: any): void
     }
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
   },
   "homepage": "https://github.com/Gr3q/types-cjs#readme",
   "dependencies": {
-    "@ci-types/gjs": "^1.0.11"
+    "@ci-types/gjs": "^1.0.12"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ci-types/cjs",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "description": "Typescript declarations for CJS - Cinnamon JavaScript",
   "types": "index.d.ts",
   "scripts": {
@@ -22,6 +22,6 @@
   },
   "homepage": "https://github.com/Gr3q/types-cjs#readme",
   "dependencies": {
-    "@ci-types/gjs": "^1.0.12"
+    "@ci-types/gjs": "^1.0.11"
   }
 }


### PR DESCRIPTION
just a minor update for global.d.ts. Most important is that I change `class Lang` and `class Signals` to interfaces. The reason therefore is that previously typescript allowed to write the following: 

```ts
const Lang = imports.Lang
```

but this throws the following error: `No JS module 'Lang' found in search path`  (even though there is no `export` keyword before the classes).