### PR TITLE
extend global with cinnamon global

### DIFF
--- a/cinnamon/globals.d.ts
+++ b/cinnamon/globals.d.ts
@@ -11,43 +11,19 @@ declare const clearTimeout: typeof imports.misc.util.clearTimeout
 		trayReloading?: boolean;
 	}
  */
-declare interface Global {
+declare interface Global extends imports.gi.Cinnamon.IGlobal{
     log: typeof imports.ui.main._logInfo;
     logWarning: typeof imports.ui.main._logWarning
     logError: typeof imports.ui.main._logError
     logTrace: typeof imports.ui.main._logTrace
-    
-    create_app_launch_context(): imports.gi.Gio.AppLaunchContext;
+    reparentActor: typeof imports.ui.main._reparentActor
+
     /** Main Cinnamon settings */
-    settings: imports.gi.Gio.Settings;
-    set_cursor(cursor: imports.gi.Cinnamon.Cursor): void;
-    unset_cursor(): void;
-    screen: imports.gi.Meta.Screen;
-    display: imports.gi.Meta.Display;
-    stage: imports.gi.Clutter.Stage;
-    /** Gets the pointer coordinates and current modifier key state */
-    get_pointer(): [number, number, imports.gi.Clutter.ModifierType]
-    /**
-     * Sets the pointer coordinates
-     * 
-     * @param x the X coordinate of the pointer, in global coordinates
-     * @param y the Y coordinate of the pointer, in global coordinates
-     */
-    set_pointer(x: number, y: number): void
-    focus_manager: imports.gi.St.FocusManager
-
-    /**
-     * @returns the current X server time from the current Clutter, Gdk, or X event. If called from outside an event handler, this may return Clutter.CURRENT_TIME (aka 0), or it may return a slightly out-of-date timestamp.
-     */
-    get_current_time(): number
-
-    ui_scale: number;
+    readonly settings: imports.gi.Gio.Settings;
     /** the directory, the cinnamon spices are placed, e.g. on Linux Mint 20.2 this is: $HOME/.local/share/cinnamon  */
-    userdatadir: string
+    readonly userdatadir: string
 
-    stage_input_mode: imports.gi.Cinnamon.StageInputMode;
-
-    reparentActor: typeof imports.ui.main['_reparentActor']
+    readonly stage: imports.gi.Clutter.Stage;
 }
 
 declare const global: Global;

--- a/cinnamon/globals.d.ts
+++ b/cinnamon/globals.d.ts
@@ -22,8 +22,6 @@ declare interface Global extends imports.gi.Cinnamon.IGlobal{
     readonly settings: imports.gi.Gio.Settings;
     /** the directory, the cinnamon spices are placed, e.g. on Linux Mint 20.2 this is: $HOME/.local/share/cinnamon  */
     readonly userdatadir: string
-
-    readonly stage: imports.gi.Clutter.Stage;
 }
 
 declare const global: Global;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ci-types/cjs",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "description": "Typescript declarations for CJS - Cinnamon JavaScript",
   "types": "index.d.ts",
   "scripts": {


### PR DESCRIPTION
Sorry for not including it yesterday already but I found the `IGlobal` just now. That way we (finally) should have pretty much all types of the `global` object (maybe some js overrides are missing). The  `stage` must be overridden in the Global type because it is not specific enough in the Cinnamon.d.ts (there it is specified as Actor but it is of type Stage). The other two are just kept as the jsdoc is better than in the cinnamon.d.ts 